### PR TITLE
Adds Highlighting of Documentation Flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Install
 -------
 
 ```bash
-mkdir -p ~/Library/Application\ Support/Avian/Bundles
-cd ~/Library/Application\ Support/Avian/Bundles
+mkdir -p ~/Library/Application\ Support/TextMate/Bundles
+cd ~/Library/Application\ Support/TextMate/Bundles
 git clone https://github.com/huacnlee/Crystal.tmbundle.git
 ```
 

--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -480,6 +480,34 @@
 			</array>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.def.crystal</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.crystal</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string> the optional name is just to catch the def also without a method-name</string>
+			<key>match</key>
+			<string>(?x)
+			         (?=def\b)                                                           # an optimization to help Oniguruma fail fast
+			         (?&lt;=^|\s)(def)\b                                                    # the def keyword
+			         ( \s+                                                               # an optional group of whitespace followed by…
+			           ( (?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?                                      # a method name prefix
+			             (?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?                                 # the method name
+			             |===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?) ) )?  # …or an operator method
+			        </string>
+			<key>name</key>
+			<string>meta.function.method.without-arguments.crystal</string>
+		</dict>
+		<dict>
 			<key>match</key>
 			<string>\b(0[xXoObB]\h(?&gt;_?\h)*|\d(?&gt;_?\d)*(\.(?![^[:space:][:digit:]])(?&gt;_?\d)*)?([eE][-+]?\d(?&gt;_?\d)*)?|0[bB][01]+)(_?(u8|u16|u32|u64|i8|i16|i32|i64|f32|f64))?\b</string>
 			<key>name</key>

--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -1549,20 +1549,40 @@
 			<string>^=end</string>
 			<key>name</key>
 			<string>comment.block.documentation.crystal</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\b(BUG|DEPRECATED|FIXME|NOTE|OPTIMIZE|TODO)\b</string>
+					<key>name</key>
+					<string>storage.type.class.todo.crystal</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
+			<key>begin</key>
+			<string>#</string>
 			<key>captures</key>
 			<dict>
-				<key>1</key>
+				<key>0</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.definition.comment.crystal</string>
 				</dict>
 			</dict>
-			<key>match</key>
-			<string>(?:^[ \t]+)?(#).*$\n?</string>
+			<key>end</key>
+			<string>\n</string>
 			<key>name</key>
 			<string>comment.line.number-sign.crystal</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\b(BUG|DEPRECATED|FIXME|NOTE|OPTIMIZE|TODO)\b</string>
+					<key>name</key>
+					<string>storage.type.class.todo.crystal</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>comment</key>

--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -489,7 +489,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(0[xX]\h(?&gt;_?\h)*|\d(?&gt;_?\d)*(\.(?![^[:space:][:digit:]])(?&gt;_?\d)*)?([eE][-+]?\d(?&gt;_?\d)*)?|0[bB][01]+)(_?(u8|u16|u32|u64|i8|i16|i32|i64|f32|f64))?\b</string>
+			<string>\b(0[xXoObB]\h(?&gt;_?\h)*|\d(?&gt;_?\d)*(\.(?![^[:space:][:digit:]])(?&gt;_?\d)*)?([eE][-+]?\d(?&gt;_?\d)*)?|0[bB][01]+)(_?(u8|u16|u32|u64|i8|i16|i32|i64|f32|f64))?\b</string>
 			<key>name</key>
 			<string>constant.numeric.crystal</string>
 		</dict>

--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -1494,7 +1494,7 @@
 			<array>
 				<dict>
 					<key>comment</key>
-					<string>Cant be named because its not neccesarily an escape.</string>
+					<string>Cant be named because its not necessarily an escape.</string>
 					<key>match</key>
 					<string>\\.</string>
 				</dict>

--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -396,7 +396,7 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>the method pattern comes from the symbol pattern, see there for a explaination</string>
+			<string>the method pattern comes from the symbol pattern, see there for a explanation</string>
 			<key>contentName</key>
 			<string>variable.parameter.function.crystal</string>
 			<key>end</key>

--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -396,9 +396,9 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>the method pattern comes from the symbol pattern, see there for a explaination</string>
 			<key>contentName</key>
 			<string>variable.parameter.function.crystal</string>
+			<string>the method pattern comes from the symbol pattern, see there for a explanation</string>
 			<key>end</key>
 			<string>\)</string>
 			<key>endCaptures</key>

--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -396,8 +396,6 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<key>contentName</key>
-			<string>variable.parameter.function.crystal</string>
 			<string>the method pattern comes from the symbol pattern, see there for a explanation</string>
 			<key>end</key>
 			<string>\)</string>
@@ -413,6 +411,18 @@
 			<string>meta.function.method.with-arguments.crystal</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>match</key>
+					<string>(@)[a-zA-Z_]\w*</string>
+					<key>name</key>
+					<string>variable.other.readwrite.instance.crystal</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b[a-z\_]\w*\b</string>
+					<key>name</key>
+					<string>variable.parameter.function.crystal</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>$self</string>
@@ -445,8 +455,6 @@
 			</dict>
 			<key>comment</key>
 			<string>same as the previous rule, but without parentheses around the arguments</string>
-			<key>contentName</key>
-			<string>variable.parameter.function.crystal</string>
 			<key>end</key>
 			<string>$</string>
 			<key>name</key>
@@ -454,38 +462,22 @@
 			<key>patterns</key>
 			<array>
 				<dict>
+					<key>match</key>
+					<string>(@)[a-zA-Z_]\w*</string>
+					<key>name</key>
+					<string>variable.other.readwrite.instance.crystal</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b[a-z\_]\w*\b</string>
+					<key>name</key>
+					<string>variable.parameter.function.crystal</string>
+				</dict>
+				<dict>
 					<key>include</key>
 					<string>$self</string>
 				</dict>
 			</array>
-		</dict>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.control.def.crystal</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.function.crystal</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string> the optional name is just to catch the def also without a method-name</string>
-			<key>match</key>
-			<string>(?x)
-			         (?=def\b)                                                           # an optimization to help Oniguruma fail fast
-			         (?&lt;=^|\s)(def)\b                                                    # the def keyword
-			         ( \s+                                                               # an optional group of whitespace followed by…
-			           ( (?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?                                      # a method name prefix
-			             (?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?                                 # the method name
-			             |===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?) ) )?  # …or an operator method
-			        </string>
-			<key>name</key>
-			<string>meta.function.method.without-arguments.crystal</string>
 		</dict>
 		<dict>
 			<key>match</key>

--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -397,8 +397,6 @@
 			</dict>
 			<key>comment</key>
 			<string>the method pattern comes from the symbol pattern, see there for a explanation</string>
-			<key>contentName</key>
-			<string>variable.parameter.function.crystal</string>
 			<key>end</key>
 			<string>\)</string>
 			<key>endCaptures</key>
@@ -413,6 +411,18 @@
 			<string>meta.function.method.with-arguments.crystal</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>match</key>
+					<string>(@)[a-zA-Z_]\w*</string>
+					<key>name</key>
+					<string>variable.other.readwrite.instance.crystal</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b[a-z\_]\w*\b</string>
+					<key>name</key>
+					<string>variable.parameter.function.crystal</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>$self</string>
@@ -445,8 +455,6 @@
 			</dict>
 			<key>comment</key>
 			<string>same as the previous rule, but without parentheses around the arguments</string>
-			<key>contentName</key>
-			<string>variable.parameter.function.crystal</string>
 			<key>end</key>
 			<string>$</string>
 			<key>name</key>
@@ -454,38 +462,22 @@
 			<key>patterns</key>
 			<array>
 				<dict>
+					<key>match</key>
+					<string>(@)[a-zA-Z_]\w*</string>
+					<key>name</key>
+					<string>variable.other.readwrite.instance.crystal</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b[a-z\_]\w*\b</string>
+					<key>name</key>
+					<string>variable.parameter.function.crystal</string>
+				</dict>
+				<dict>
 					<key>include</key>
 					<string>$self</string>
 				</dict>
 			</array>
-		</dict>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.control.def.crystal</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.function.crystal</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string> the optional name is just to catch the def also without a method-name</string>
-			<key>match</key>
-			<string>(?x)
-			         (?=def\b)                                                           # an optimization to help Oniguruma fail fast
-			         (?&lt;=^|\s)(def)\b                                                    # the def keyword
-			         ( \s+                                                               # an optional group of whitespace followed by…
-			           ( (?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?                                      # a method name prefix
-			             (?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?                                 # the method name
-			             |===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?) ) )?  # …or an operator method
-			        </string>
-			<key>name</key>
-			<string>meta.function.method.without-arguments.crystal</string>
 		</dict>
 		<dict>
 			<key>match</key>
@@ -1494,7 +1486,7 @@
 			<array>
 				<dict>
 					<key>comment</key>
-					<string>Cant be named because its not necessarily an escape.</string>
+					<string>Cant be named because its not neccesarily an escape.</string>
 					<key>match</key>
 					<string>\\.</string>
 				</dict>
@@ -1549,40 +1541,20 @@
 			<string>^=end</string>
 			<key>name</key>
 			<string>comment.block.documentation.crystal</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>\b(BUG|DEPRECATED|FIXME|NOTE|OPTIMIZE|TODO)\b</string>
-					<key>name</key>
-					<string>storage.type.class.todo.crystal</string>
-				</dict>
-			</array>
 		</dict>
 		<dict>
-			<key>begin</key>
-			<string>#</string>
 			<key>captures</key>
 			<dict>
-				<key>0</key>
+				<key>1</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.definition.comment.crystal</string>
 				</dict>
 			</dict>
-			<key>end</key>
-			<string>\n</string>
+			<key>match</key>
+			<string>(?:^[ \t]+)?(#).*$\n?</string>
 			<key>name</key>
 			<string>comment.line.number-sign.crystal</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>\b(BUG|DEPRECATED|FIXME|NOTE|OPTIMIZE|TODO)\b</string>
-					<key>name</key>
-					<string>storage.type.class.todo.crystal</string>
-				</dict>
-			</array>
 		</dict>
 		<dict>
 			<key>comment</key>


### PR DESCRIPTION
The flags are noted in the [docs](https://crystal-lang.org/docs/conventions/documenting_code.html).

It also fixes some minor spelling mistakes.