### PR TITLE
Improves handling of method arguments

### DIFF
--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -397,8 +397,6 @@
 			</dict>
 			<key>comment</key>
 			<string>the method pattern comes from the symbol pattern, see there for a explanation</string>
-			<key>contentName</key>
-			<string>variable.parameter.function.crystal</string>
 			<key>end</key>
 			<string>\)</string>
 			<key>endCaptures</key>
@@ -413,6 +411,18 @@
 			<string>meta.function.method.with-arguments.crystal</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>match</key>
+					<string>(@)[a-zA-Z_]\w*</string>
+					<key>name</key>
+					<string>variable.other.readwrite.instance.crystal</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b[a-z\_]\w*\b</string>
+					<key>name</key>
+					<string>variable.parameter.function.crystal</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>$self</string>
@@ -445,14 +455,24 @@
 			</dict>
 			<key>comment</key>
 			<string>same as the previous rule, but without parentheses around the arguments</string>
-			<key>contentName</key>
-			<string>variable.parameter.function.crystal</string>
 			<key>end</key>
 			<string>$</string>
 			<key>name</key>
 			<string>meta.function.method.with-arguments.crystal</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>match</key>
+					<string>(@)[a-zA-Z_]\w*</string>
+					<key>name</key>
+					<string>variable.other.readwrite.instance.crystal</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b[a-z\_]\w*\b</string>
+					<key>name</key>
+					<string>variable.parameter.function.crystal</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>$self</string>

--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -1549,20 +1549,40 @@
 			<string>^=end</string>
 			<key>name</key>
 			<string>comment.block.documentation.crystal</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\b(BUG|DEPRECATED|FIXME|NOTE|OPTIMIZE|TODO)\b</string>
+					<key>name</key>
+					<string>storage.type.class.todo.crystal</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
+			<key>begin</key>
+			<string>#</string>
 			<key>captures</key>
 			<dict>
-				<key>1</key>
+				<key>0</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.definition.comment.crystal</string>
 				</dict>
 			</dict>
-			<key>match</key>
-			<string>(?:^[ \t]+)?(#).*$\n?</string>
+			<key>end</key>
+			<string>\n</string>
 			<key>name</key>
 			<string>comment.line.number-sign.crystal</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\b(BUG|DEPRECATED|FIXME|NOTE|OPTIMIZE|TODO)\b</string>
+					<key>name</key>
+					<string>storage.type.class.todo.crystal</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>comment</key>

--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -489,7 +489,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(0[xX]\h(?&gt;_?\h)*|\d(?&gt;_?\d)*(\.(?![^[:space:][:digit:]])(?&gt;_?\d)*)?([eE][-+]?\d(?&gt;_?\d)*)?|0[bB][01]+)(_?(u8|u16|u32|u64|i8|i16|i32|i64|f32|f64))?\b</string>
+			<string>\b(0[xXoObB]\h(?&gt;_?\h)*|\d(?&gt;_?\d)*(\.(?![^[:space:][:digit:]])(?&gt;_?\d)*)?([eE][-+]?\d(?&gt;_?\d)*)?|0[bB][01]+)(_?(u8|u16|u32|u64|i8|i16|i32|i64|f32|f64))?\b</string>
 			<key>name</key>
 			<string>constant.numeric.crystal</string>
 		</dict>

--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -1494,7 +1494,7 @@
 			<array>
 				<dict>
 					<key>comment</key>
-					<string>Cant be named because its not neccesarily an escape.</string>
+					<string>Cant be named because its not necessarily an escape.</string>
 					<key>match</key>
 					<string>\\.</string>
 				</dict>

--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -396,7 +396,7 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>the method pattern comes from the symbol pattern, see there for a explaination</string>
+			<string>the method pattern comes from the symbol pattern, see there for a explanation</string>
 			<key>contentName</key>
 			<string>variable.parameter.function.crystal</string>
 			<key>end</key>


### PR DESCRIPTION
The old version made all unclassified entries params. This considers the whitespace around the param as part of the param. This made double-clicking on the param to highlight it include the whitespace and interrupts my workflow. 

This isn't a perfect fix as it doesn't deal with the nested parens issue, but it is a much to be enjoyed improvement.