### PR TITLE
Improves handling of method arguments

### DIFF
--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -480,6 +480,34 @@
 			</array>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.def.crystal</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.crystal</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string> the optional name is just to catch the def also without a method-name</string>
+			<key>match</key>
+			<string>(?x)
+			         (?=def\b)                                                           # an optimization to help Oniguruma fail fast
+			         (?&lt;=^|\s)(def)\b                                                    # the def keyword
+			         ( \s+                                                               # an optional group of whitespace followed by…
+			           ( (?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?                                      # a method name prefix
+			             (?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?                                 # the method name
+			             |===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?) ) )?  # …or an operator method
+			        </string>
+			<key>name</key>
+			<string>meta.function.method.without-arguments.crystal</string>
+		</dict>
+		<dict>
 			<key>match</key>
 			<string>\b(0[xXoObB]\h(?&gt;_?\h)*|\d(?&gt;_?\d)*(\.(?![^[:space:][:digit:]])(?&gt;_?\d)*)?([eE][-+]?\d(?&gt;_?\d)*)?|0[bB][01]+)(_?(u8|u16|u32|u64|i8|i16|i32|i64|f32|f64))?\b</string>
 			<key>name</key>

--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -396,9 +396,9 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>the method pattern comes from the symbol pattern, see there for a explaination</string>
 			<key>contentName</key>
 			<string>variable.parameter.function.crystal</string>
+			<string>the method pattern comes from the symbol pattern, see there for a explanation</string>
 			<key>end</key>
 			<string>\)</string>
 			<key>endCaptures</key>

--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -396,8 +396,6 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<key>contentName</key>
-			<string>variable.parameter.function.crystal</string>
 			<string>the method pattern comes from the symbol pattern, see there for a explanation</string>
 			<key>end</key>
 			<string>\)</string>
@@ -413,6 +411,18 @@
 			<string>meta.function.method.with-arguments.crystal</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>match</key>
+					<string>(@)[a-zA-Z_]\w*</string>
+					<key>name</key>
+					<string>variable.other.readwrite.instance.crystal</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b[a-z\_]\w*\b</string>
+					<key>name</key>
+					<string>variable.parameter.function.crystal</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>$self</string>
@@ -445,8 +455,6 @@
 			</dict>
 			<key>comment</key>
 			<string>same as the previous rule, but without parentheses around the arguments</string>
-			<key>contentName</key>
-			<string>variable.parameter.function.crystal</string>
 			<key>end</key>
 			<string>$</string>
 			<key>name</key>
@@ -454,38 +462,22 @@
 			<key>patterns</key>
 			<array>
 				<dict>
+					<key>match</key>
+					<string>(@)[a-zA-Z_]\w*</string>
+					<key>name</key>
+					<string>variable.other.readwrite.instance.crystal</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b[a-z\_]\w*\b</string>
+					<key>name</key>
+					<string>variable.parameter.function.crystal</string>
+				</dict>
+				<dict>
 					<key>include</key>
 					<string>$self</string>
 				</dict>
 			</array>
-		</dict>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.control.def.crystal</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.function.crystal</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string> the optional name is just to catch the def also without a method-name</string>
-			<key>match</key>
-			<string>(?x)
-			         (?=def\b)                                                           # an optimization to help Oniguruma fail fast
-			         (?&lt;=^|\s)(def)\b                                                    # the def keyword
-			         ( \s+                                                               # an optional group of whitespace followed by…
-			           ( (?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?                                      # a method name prefix
-			             (?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?                                 # the method name
-			             |===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?) ) )?  # …or an operator method
-			        </string>
-			<key>name</key>
-			<string>meta.function.method.without-arguments.crystal</string>
 		</dict>
 		<dict>
 			<key>match</key>


### PR DESCRIPTION
The old version made all unclassified entries params. This considers the whitespace around the param as part of the param. This made double-clicking on the param to highlight it include the whitespace and interrupts my workflow. 

This isn't a perfect fix as it doesn't deal with the nested parens issue, but it is a much to be enjoyed improvement.