### PR TITLE
Use C instead of R as the syntax shortcut

### DIFF
--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -86,7 +86,7 @@
 		|   ^=end
 		)</string>
 	<key>keyEquivalent</key>
-	<string>^~R</string>
+	<string>^~C</string>
 	<key>name</key>
 	<string>Crystal</string>
 	<key>patterns</key>


### PR DESCRIPTION
I assume this is a relic from branching of the Ruby syntax initially. I've changed the shortcut from `Shift+Ctrl+Alt+R` to `Shift+Ctrl+Alt+C`.