### PR TITLE
Highlight interpolated Crystal similar to Ruby

### DIFF
--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -2282,39 +2282,35 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>captures</key>
+					<key>begin</key>
+					<string>#\{</string>
+					<key>beginCaptures</key>
 					<dict>
 						<key>0</key>
 						<dict>
 							<key>name</key>
-							<string>punctuation.section.embedded.crystal</string>
+							<string>punctuation.section.embedded.begin.crystal</string>
+						</dict>
+					</dict>
+					<key>contentName</key>
+					<string>source.crystal</string>
+					<key>end</key>
+					<string>(\})</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.embedded.end.crystal</string>
 						</dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>source.crystal.embedded.source.empty</string>
+							<string>source.crystal</string>
 						</dict>
 					</dict>
-					<key>match</key>
-					<string>#\{(\})</string>
 					<key>name</key>
-					<string>source.crystal.embedded.source</string>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>#\{</string>
-					<key>captures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.embedded.crystal</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>\}</string>
-					<key>name</key>
-					<string>source.crystal.embedded.source</string>
+					<string>meta.embedded.line.crystal</string>
 					<key>patterns</key>
 					<array>
 						<dict>


### PR DESCRIPTION
Interpolated Crystal did not get highlighted as it would in Ruby. This pull request addresses it.

I'm not sure why this was different from Ruby, but if I accidentally broke something by making this change, feel free to point that out.

**Before**

<img width="1144" alt="before" src="https://user-images.githubusercontent.com/503025/82872665-a2b2d980-9f33-11ea-890b-dfb71a686cbc.png">

**After**

<img width="1142" alt="after" src="https://user-images.githubusercontent.com/503025/82872692-acd4d800-9f33-11ea-90be-43fc01c8a634.png">