### PR TITLE
Do not color output of `crystal run`

### DIFF
--- a/Commands/Run.tmCommand
+++ b/Commands/Run.tmCommand
@@ -9,7 +9,7 @@
 require "#{ENV["TM_SUPPORT_PATH"]}/lib/escape"
 require "#{ENV["TM_SUPPORT_PATH"]}/lib/tm/executor"
 
-TextMate::Executor.run(e_sh(ENV['TM_CRYSTAL'] || 'crystal'), 'run', ENV['TM_FILEPATH'], :verb =&gt; "Running")</string>
+TextMate::Executor.run(e_sh(ENV['TM_CRYSTAL'] || 'crystal'), 'run', '--no-color', ENV['TM_FILEPATH'], :verb =&gt; "Running")</string>
 	<key>input</key>
 	<string>document</string>
 	<key>inputFormat</key>


### PR DESCRIPTION
TextMate does not parse the terminal escape sequences for each color,
leaving them in the final output. By passing `--no-color`, we tell
Crystal to not color the output.

**Before**
<img width="672" alt="before" src="https://user-images.githubusercontent.com/503025/82940852-b0994680-9f95-11ea-986b-4d21e742397b.png">

**After**
<img width="672" alt="after" src="https://user-images.githubusercontent.com/503025/82940872-b727be00-9f95-11ea-8528-6f226e15e732.png">
