### PR TITLE
Fix operator assignment matching

### DIFF
--- a/Syntaxes/Crystal.tmLanguage
+++ b/Syntaxes/Crystal.tmLanguage
@@ -556,7 +556,7 @@
 			<key>comment</key>
 			<string>Needs higher precidence than regular expressions.</string>
 			<key>match</key>
-			<string>/=</string>
+			<string>(?&lt;!\()/=</string>
 			<key>name</key>
 			<string>keyword.operator.assignment.augmented.crystal</string>
 		</dict>


### PR DESCRIPTION
Directly taken from Ruby syntax. `(=/` was incorrectly matched to the scope `keyword.operator.assignment.augmented`.

**Before**

<img width="539" alt="Screenshot 2021-07-04 at 17 56 01" src="https://user-images.githubusercontent.com/503025/124391606-ac3f7100-dcf1-11eb-9b76-ea6e34220a1d.png">

**After**

<img width="539" alt="Screenshot 2021-07-04 at 17 56 27" src="https://user-images.githubusercontent.com/503025/124391613-b1042500-dcf1-11eb-8abf-ba25b6f9bcf0.png">


