### PR TITLE
Improve indentation rules

### DIFF
--- a/Preferences/Indent.tmPreferences
+++ b/Preferences/Indent.tmPreferences
@@ -13,7 +13,12 @@
 		<key>increaseIndentPattern</key>
 		<string>(?x)^
     (\s*
-        (module|class|def
+        ((private\s+)?module
+        |((private|abstract|private\s+abstract)\s+)?(class|struct)
+        |(private\s+)?enum
+        |((private|protected)\s+)?def
+        |(private\s+)?macro
+        |union|lib
         |unless|if|else|elsif
         |case|when
         |begin|rescue|ensure


### PR DESCRIPTION

- Add indentation for `struct`, `private struct`, `abstract struct` and `private abstract struct`.
- Add indentation for `enum` and `private enum`
- Add indentation for `private module`
- Add indentation for `private class`, `abstract class` and `private abstract class`.
- Add indentation for `private def` and `protected def`
- Add indentation for `macro` and `private macro`